### PR TITLE
【参加者全取得ユースケースのIF修正】プラハチャレンジをDDDで実装してみる

### DIFF
--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/infra/db/query-service/get-all-member-query-service.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/infra/db/query-service/get-all-member-query-service.ts
@@ -33,9 +33,9 @@ export class GetAllMemberQueryService implements IGetAllMemberQueryService {
     ]);
 
     const memberList: GetAllMemberDTO = memberDataList.map((memberData) => {
-      const { id, name, activityStatus } = memberData;
+      const { id, name, email, activityStatus } = memberData;
 
-      return { id, name, activityStatus, pairID: null, teamID: null };
+      return { id, name, email, activityStatus, pairID: null, teamID: null };
     });
     teamDataList.forEach((nestedTeamData: INestedTeamData) => {
       const teamID = nestedTeamData.id;

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/query-service-interface/get-all-member-query-service.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/query-service-interface/get-all-member-query-service.ts
@@ -1,6 +1,7 @@
 interface OneOfGetAllMemberDTO {
   id: string;
   name: string;
+  email: string;
   activityStatus: string;
   pairID: string | null;
   teamID: string | null;

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/query-service-interface/get-all-member-query-service.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/query-service-interface/get-all-member-query-service.ts
@@ -1,12 +1,11 @@
-import {
-  MemberDTO,
-  TeamDTO,
-} from "usecase/query-service-interface/domain-dtos";
-
-export interface GetAllMemberDTO {
-  teamList: TeamDTO[];
-  independentMemberList: MemberDTO[];
+interface OneOfGetAllMemberDTO {
+  id: string;
+  name: string;
+  activityStatus: string;
+  pairID: string | null;
+  teamID: string | null;
 }
+export type GetAllMemberDTO = OneOfGetAllMemberDTO[];
 
 export interface IGetAllMemberQueryService {
   execute(): Promise<GetAllMemberDTO>;


### PR DESCRIPTION
## 対応内容

全参加者を取得するユースケースについて、返り値の型を

```typescript
type GetAllMemberDTO = {
  teamList: {
    id: string;
    name: string;
    pairList: {
      id: string;
      name: string;
      memberList: {
        id: string;
        name: string;
        email: string;
        activityStatus: string;
      }[];
    }[];
  }[];
  independentMemberList: {
    id: string;
    name: string;
    email: string;
    activityStatus: string;
  }[];
}[];
```

みたいなかんじでネストした形で返してたんですけど、

```typescript
type GetAllMemberDTO = {
  id: string;
  name: string;
  email: string;
  activityStatus: string;
  pairID: string | null;
  teamID: string | null;
}[]
```

こうしてあげたほうがクライアント側でも使いやすいかなと思ってそのようにインターフェースを修正しました。

## 見てほしいところ

いや、元のインターフェースのほうが使いやすいよ！などあったら教えて下さい。