### PR TITLE
【参加者の削除】プラハチャレンジをDDDで実装してみる

### DIFF
--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/member/member-repository-interface.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/member/member-repository-interface.ts
@@ -6,4 +6,5 @@ export interface IMemberRepository {
   getByID(id: Identifier): Promise<Member | null>;
   getAll(): Promise<Member[]>;
   update(member: Member): Promise<void>;
+  delete(member: Member): Promise<void>;
 }

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/member/service/delete-member-service.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/member/service/delete-member-service.ts
@@ -1,0 +1,29 @@
+import { Member } from "domain/member/entity/member";
+import { IMemberRepository } from "domain/member/member-repository-interface";
+import { IsMemberExistsInTeam } from "domain/team/domain-service/is-member-exists-in-team";
+import { ITeamRepository } from "domain/team/team-repository-interface";
+
+export class DeleteMemberService {
+  private readonly memberRepository: IMemberRepository;
+  private readonly teamRepository: ITeamRepository;
+
+  public constructor(
+    memberRepository: IMemberRepository,
+    teamRepository: ITeamRepository,
+  ) {
+    this.memberRepository = memberRepository;
+    this.teamRepository = teamRepository;
+  }
+
+  public execute = async (member: Member): Promise<void> => {
+    if (
+      await new IsMemberExistsInTeam(this.teamRepository).execute(member.id)
+    ) {
+      throw new Error(
+        "Cannnot delete member because member is belongs to pair",
+      );
+    }
+
+    await this.memberRepository.delete(member);
+  };
+}

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/infra/db/repository/member-repository.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/infra/db/repository/member-repository.ts
@@ -60,4 +60,20 @@ export class MemberRepository implements IMemberRepository {
       },
     });
   };
+
+  public delete = async (member: Member): Promise<void> => {
+    const id = member.id.value;
+
+    await this.prisma.exerciseOnMember.deleteMany({
+      where: {
+        memberId: id,
+      },
+    });
+
+    await this.prisma.member.delete({
+      where: {
+        id,
+      },
+    });
+  };
 }

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/test/stub/use-case/delete-member.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/test/stub/use-case/delete-member.ts
@@ -1,0 +1,68 @@
+const createdAt = new Date();
+const updatedAt = new Date();
+
+export const nestedTeamData = {
+  id: "0a3fc828-dc70-49c8-9690-0ed78e212055",
+  name: "1",
+  createdAt,
+  updatedAt,
+  pair: [
+    {
+      id: "9da36d6e-c4a2-4215-bfb1-fa62acebd725",
+      name: "a",
+      teamId: "0a3fc828-dc70-49c8-9690-0ed78e212055",
+      createdAt,
+      updatedAt,
+      member: [
+        {
+          memberId: "bde2a250-f30d-4b80-90cd-ba2387e2b90f",
+          pairId: "9da36d6e-c4a2-4215-bfb1-fa62acebd725",
+          createdAt,
+          updatedAt,
+        },
+        {
+          memberId: "4f19e241-baaa-4e59-8ae7-63f1d52cece2",
+          pairId: "9da36d6e-c4a2-4215-bfb1-fa62acebd725",
+          createdAt,
+          updatedAt,
+        },
+      ],
+    },
+    {
+      id: "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
+      name: "b",
+      teamId: "0a3fc828-dc70-49c8-9690-0ed78e212055",
+      createdAt,
+      updatedAt,
+      member: [
+        {
+          memberId: "e6744e62-0f74-4b13-bcb3-d09cb20fe551",
+          pairId: "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
+          createdAt,
+          updatedAt,
+        },
+        {
+          memberId: "4b475b13-4bfa-498e-9ae8-cec321d8ddd3",
+          pairId: "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
+          createdAt,
+          updatedAt,
+        },
+        {
+          memberId: "9d553bbf-1840-49bf-8d4a-9c9deb39b31e",
+          pairId: "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
+          createdAt,
+          updatedAt,
+        },
+      ],
+    },
+  ],
+};
+
+export const memberData = {
+  id: "a5294443-5945-4a74-aac0-593671ed166b",
+  name: "Allison Berge",
+  email: "Rosa36@gmail.com",
+  activityStatus: "在籍中",
+  createdAt,
+  updatedAt,
+};

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/test/usecase/delete-member.test.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/test/usecase/delete-member.test.ts
@@ -1,0 +1,34 @@
+import { DeleteMemberService } from "domain/member/service/delete-member-service";
+import { MockContext, Context, createMockContext } from "infra/db/context";
+import { MemberRepository } from "infra/db/repository/member-repository";
+import { TeamRepository } from "infra/db/repository/team-repository";
+import { memberData } from "test/stub/use-case/delete-member";
+import { DeleteMember } from "usecase/delete-member";
+
+let mockContext: MockContext;
+let context: Context;
+
+beforeEach(() => {
+  mockContext = createMockContext();
+  context = (mockContext as unknown) as Context;
+});
+
+describe("DeleteMember", () => {
+  test("参加者を削除する", async () => {
+    mockContext.prisma.member.findUnique.mockResolvedValue(memberData);
+    mockContext.prisma.memberOnPair.findMany.mockResolvedValue([]);
+
+    const memberRepository = new MemberRepository(context);
+    const teamRepository = new TeamRepository(context);
+    const deleteMemberService = new DeleteMemberService(
+      memberRepository,
+      teamRepository,
+    );
+    const executeSpy = jest.spyOn(deleteMemberService, "execute");
+    const instance = new DeleteMember(memberRepository, deleteMemberService);
+
+    await instance.execute(memberData.id);
+
+    expect(executeSpy).toBeCalled();
+  });
+});

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/delete-member.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/delete-member.ts
@@ -1,0 +1,28 @@
+import { IMemberRepository } from "domain/member/member-repository-interface";
+import { DeleteMemberService } from "domain/member/service/delete-member-service";
+import { Identifier } from "domain/shared/identifier";
+
+export class DeleteMember {
+  private readonly memberRepository: IMemberRepository;
+  private readonly deleteMemberService: DeleteMemberService;
+
+  public constructor(
+    memberRepository: IMemberRepository,
+    deleteMemberService: DeleteMemberService,
+  ) {
+    this.memberRepository = memberRepository;
+    this.deleteMemberService = deleteMemberService;
+  }
+
+  public execute = async (memberID: string): Promise<void> => {
+    const member = await this.memberRepository.getByID(
+      new Identifier(memberID),
+    );
+
+    if (member === null) {
+      throw new Error("Member is not exists");
+    }
+
+    await this.deleteMemberService.execute(member);
+  };
+}


### PR DESCRIPTION
## 対応内容

- [x] 参加者リポジトリに削除メソッド追加
  - [x] [インターフェース](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/63/files#diff-62a799c87c441c3a514cd3e7d140919e8c53bedfa17853775507e2c2e81ebb13)
  - [x] [実装](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/63/files#diff-fe52551d8a4ef9c7d9c2ad8ddf90ede16ac75e5dca4dbe68601530e704368f18)
  - [ ] [テスト]()
- [x] 参加者を削除するドメインサービス
  - [x] [実装](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/63/files#diff-3d690d42ea475298a16138d5ccb487eae5a31f27295f3cc80161c8857b8151c4)
  - [ ] [テスト]()
- [x] 参加者を削除するユースケース
  - [x] [実装](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/63/files#diff-3ae2e4537b2427caac614ab254d1bcdc537f23e1d144b6182ba30f1dcfe1bfe8)
  - [x] [テスト](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/63/files#diff-6bbc584f0fe2bd158072b32e82442ac7702292e3665cf041a9833eff9813a059)
  - [x] [スタブ](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/63/files#diff-0d254f7a908a5ed28fd8fae7f7f1b8f7bdaa70b4cb227b514772069b0d7e02d6)

## 見てほしいところ

仕様的に抜けもれないか見てほしいですん