### PR TITLE
【参加者をペアから削除】プラハチャレンジをDDDで実装してみる

### DIFF
--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/__tests__/__stubs__/usecase/remove-member-from-pair.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/__tests__/__stubs__/usecase/remove-member-from-pair.ts
@@ -1,0 +1,177 @@
+import { MemberFactory } from "domain/member/service/member-factory";
+import { PairFactory } from "domain/team/service/pair-factory";
+import { TeamFactory } from "domain/team/service/team-factory";
+
+const createdAt = new Date();
+const updatedAt = new Date();
+
+const nestedTeamData = {
+  id: "0a3fc828-dc70-49c8-9690-0ed78e212055",
+  name: "1",
+  createdAt,
+  updatedAt,
+  pair: [
+    {
+      id: "9da36d6e-c4a2-4215-bfb1-fa62acebd725",
+      name: "a",
+      teamId: "0a3fc828-dc70-49c8-9690-0ed78e212055",
+      createdAt,
+      updatedAt,
+      member: [
+        {
+          memberId: "bde2a250-f30d-4b80-90cd-ba2387e2b90f",
+          pairId: "9da36d6e-c4a2-4215-bfb1-fa62acebd725",
+          createdAt,
+          updatedAt,
+        },
+        {
+          memberId: "4f19e241-baaa-4e59-8ae7-63f1d52cece2",
+          pairId: "9da36d6e-c4a2-4215-bfb1-fa62acebd725",
+          createdAt,
+          updatedAt,
+        },
+      ],
+    },
+    {
+      id: "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
+      name: "b",
+      teamId: "0a3fc828-dc70-49c8-9690-0ed78e212055",
+      createdAt,
+      updatedAt,
+      member: [
+        {
+          memberId: "e6744e62-0f74-4b13-bcb3-d09cb20fe551",
+          pairId: "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
+          createdAt,
+          updatedAt,
+        },
+        {
+          memberId: "4b475b13-4bfa-498e-9ae8-cec321d8ddd3",
+          pairId: "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
+          createdAt,
+          updatedAt,
+        },
+        {
+          memberId: "9d553bbf-1840-49bf-8d4a-9c9deb39b31e",
+          pairId: "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
+          createdAt,
+          updatedAt,
+        },
+      ],
+    },
+  ],
+};
+
+const memberDataList = [
+  {
+    id: "bde2a250-f30d-4b80-90cd-ba2387e2b90f",
+    name: "Doug Bahringer",
+    email: "Katelyn_Kshlerin@gmail.com",
+    activityStatus: "在籍中",
+    createdAt,
+    updatedAt,
+  },
+  {
+    id: "4f19e241-baaa-4e59-8ae7-63f1d52cece2",
+    name: "Brittany Ortiz",
+    email: "Beau_Boyle4@gmail.com",
+    activityStatus: "在籍中",
+    createdAt,
+    updatedAt,
+  },
+  {
+    id: "e6744e62-0f74-4b13-bcb3-d09cb20fe551",
+    name: "Yvette Beahan",
+    email: "Pamela69@gmail.com",
+    activityStatus: "在籍中",
+    createdAt,
+    updatedAt,
+  },
+  {
+    id: "4b475b13-4bfa-498e-9ae8-cec321d8ddd3",
+    name: "Amanda Reilly MD",
+    email: "Cordie.Beahan@hotmail.com",
+    activityStatus: "在籍中",
+    createdAt,
+    updatedAt,
+  },
+  {
+    id: "9d553bbf-1840-49bf-8d4a-9c9deb39b31e",
+    name: "Dr. Stanley Wilderman",
+    email: "Leo.Corwin44@gmail.com",
+    activityStatus: "在籍中",
+    createdAt,
+    updatedAt,
+  },
+];
+
+const { id: teamId, name: teamName } = nestedTeamData;
+const pairList = nestedTeamData.pair.map((pairData) => {
+  const memberIDList = pairData.member.map((m) => m.memberId);
+  const memberList = memberDataList
+    .filter((memberData) => memberIDList.includes(memberData.id))
+    .map((memberData) =>
+      MemberFactory.execute({
+        id: memberData.id,
+        name: memberData.name,
+        email: memberData.email,
+        activityStatus: memberData.activityStatus,
+      }),
+    );
+
+  return PairFactory.execute({
+    id: pairData.id,
+    name: pairData.name,
+    memberList,
+  });
+});
+
+export const team = TeamFactory.execute({
+  id: teamId,
+  name: teamName,
+  pairList,
+});
+
+const expectedPairList = [
+  PairFactory.execute({
+    id: nestedTeamData.pair[0].id,
+    name: nestedTeamData.pair[0].name,
+    memberList: [
+      MemberFactory.execute({
+        id: memberDataList[0].id,
+        name: memberDataList[0].name,
+        email: memberDataList[0].email,
+        activityStatus: memberDataList[0].activityStatus,
+      }),
+      MemberFactory.execute({
+        id: memberDataList[1].id,
+        name: memberDataList[1].name,
+        email: memberDataList[1].email,
+        activityStatus: memberDataList[1].activityStatus,
+      }),
+    ],
+  }),
+  PairFactory.execute({
+    id: nestedTeamData.pair[1].id,
+    name: nestedTeamData.pair[1].name,
+    memberList: [
+      MemberFactory.execute({
+        id: memberDataList[2].id,
+        name: memberDataList[2].name,
+        email: memberDataList[2].email,
+        activityStatus: memberDataList[2].activityStatus,
+      }),
+      MemberFactory.execute({
+        id: memberDataList[3].id,
+        name: memberDataList[3].name,
+        email: memberDataList[3].email,
+        activityStatus: memberDataList[3].activityStatus,
+      }),
+    ],
+  }),
+];
+export const expectedTeam = TeamFactory.execute({
+  id: nestedTeamData.id,
+  name: nestedTeamData.name,
+  pairList: expectedPairList,
+});

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/__tests__/usecase/add-member-to-pair.test.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/__tests__/usecase/add-member-to-pair.test.ts
@@ -48,9 +48,11 @@ describe("AddMemberToPair", () => {
 
     await addMemberToPairInstance.execute(memberID, pairID);
 
-    // TODO: ダサいので代替手段考える
-    expect(JSON.stringify(teamRepositoryUpdateSpy.mock.calls[0][0])).toEqual(
-      JSON.stringify(expectedTeam),
+    const argsPassedToSpy = teamRepositoryUpdateSpy.mock.calls[0][0];
+    const allPairEquals = argsPassedToSpy.pairList.every((pair) =>
+      expectedTeam.pairList.some((expectedPair) => expectedPair.equals(pair)),
     );
+
+    expect(allPairEquals).toBe(true);
   });
 });

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/__tests__/usecase/remove-member-from-pair.test.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/__tests__/usecase/remove-member-from-pair.test.ts
@@ -37,9 +37,11 @@ describe("RemoveMemberFromPair", () => {
 
     await removeMemberFromPair.execute({ memberID, pairID });
 
-    // TODO: ダサいので代替手段考える
-    expect(JSON.stringify(teamRepositoryUpdateSpy.mock.calls[0][0])).toEqual(
-      JSON.stringify(expectedTeam),
+    const argsPassedToSpy = teamRepositoryUpdateSpy.mock.calls[0][0];
+    const allPairEquals = argsPassedToSpy.pairList.every((pair) =>
+      expectedTeam.pairList.some((expectedPair) => expectedPair.equals(pair)),
     );
+
+    expect(allPairEquals).toBe(true);
   });
 });

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/__tests__/usecase/remove-member-from-pair.test.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/__tests__/usecase/remove-member-from-pair.test.ts
@@ -1,16 +1,14 @@
 import {
   expectedTeam,
-  member,
   team,
-} from "__tests__/__stubs__/usecase/add-member-to-pair";
+} from "__tests__/__stubs__/usecase/remove-member-from-pair";
 import {
   MockContext,
   Context,
   createMockContext,
 } from "infrastructure/db/context";
-import { MemberRepository } from "infrastructure/db/repository/member-repository";
 import { TeamRepository } from "infrastructure/db/repository/team-repository";
-import { AddMemberToPair } from "usecase/add-member-to-pair";
+import { RemoveMemberFromPair } from "usecase/remove-member-from-pair";
 
 let mockContext: MockContext;
 let context: Context;
@@ -26,27 +24,18 @@ jest.mock("infrastructure/db/repository/team-repository", () => ({
     update: jest.fn(),
   })),
 }));
-jest.mock("infrastructure/db/repository/member-repository", () => ({
-  MemberRepository: jest.fn().mockImplementation(() => ({
-    getByID: () => member,
-  })),
-}));
 
-describe("AddMemberToPair", () => {
+describe("RemoveMemberFromPair", () => {
   test("チームリポジトリに適切なチームオブジェクトを渡して更新メソッドを実行する", async () => {
     const teamRepository = new TeamRepository(context);
-    const memberRepository = new MemberRepository(context);
-    const addMemberToPairInstance = new AddMemberToPair(
-      teamRepository,
-      memberRepository,
-    );
+    const removeMemberFromPair = new RemoveMemberFromPair(teamRepository);
     const [memberID, pairID] = [
-      "a5294443-5945-4a74-aac0-593671ed166b",
-      "9da36d6e-c4a2-4215-bfb1-fa62acebd725",
+      "9d553bbf-1840-49bf-8d4a-9c9deb39b31e",
+      "e9ffd5ef-ebdb-4198-b510-261bc34903f4",
     ];
     const teamRepositoryUpdateSpy = jest.spyOn(teamRepository, "update");
 
-    await addMemberToPairInstance.execute(memberID, pairID);
+    await removeMemberFromPair.execute({ memberID, pairID });
 
     // TODO: ダサいので代替手段考える
     expect(JSON.stringify(teamRepositoryUpdateSpy.mock.calls[0][0])).toEqual(

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/remove-member-from-pair.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/remove-member-from-pair.ts
@@ -1,0 +1,48 @@
+import { Identifier } from "domain/__shared__/identifier";
+import { PairFactory } from "domain/team/service/pair-factory";
+import { TeamFactory } from "domain/team/service/team-factory";
+import { ITeamRepository } from "domain/team/team-repository-interface";
+
+interface IExecuteProps {
+  memberID: string;
+  pairID: string;
+}
+export class RemoveMemberFromPair {
+  private readonly teamRepository: ITeamRepository;
+
+  public constructor(teamRepository: ITeamRepository) {
+    this.teamRepository = teamRepository;
+  }
+
+  public execute = async (props: IExecuteProps): Promise<void> => {
+    const currentTeam = await this.teamRepository.getByPairID({
+      pairID: new Identifier(props.pairID),
+    });
+
+    if (currentTeam === null) {
+      throw new Error("Pair is not exists");
+    }
+
+    const replacedPairList = currentTeam.pairList.map((currentPair) =>
+      currentPair.memberList.some(
+        (member) => member.id.value === props.memberID,
+      )
+        ? PairFactory.execute({
+            id: currentPair.id.value,
+            name: currentPair.name,
+            memberList: currentPair.memberList.filter(
+              (member) => member.id.value !== props.memberID,
+            ),
+          })
+        : currentPair,
+    );
+
+    const replacedTeam = TeamFactory.execute({
+      id: currentTeam.id.value,
+      name: currentTeam.name,
+      pairList: replacedPairList,
+    });
+
+    await this.teamRepository.update(replacedTeam);
+  };
+}

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/remove-member-from-pair.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/remove-member-from-pair.ts
@@ -24,14 +24,14 @@ export class RemoveMemberFromPair {
     }
 
     const replacedPairList = currentTeam.pairList.map((currentPair) =>
-      currentPair.memberList.some(
-        (member) => member.id.value === props.memberID,
+      currentPair.memberList.some((member) =>
+        member.id.equals(new Identifier(props.memberID)),
       )
         ? PairFactory.execute({
             id: currentPair.id.value,
             name: currentPair.name,
             memberList: currentPair.memberList.filter(
-              (member) => member.id.value !== props.memberID,
+              (member) => !member.id.equals(new Identifier(props.memberID)),
             ),
           })
         : currentPair,


### PR DESCRIPTION
## 対応内容

- [x] 参加者をペアから削除するユースケース実装
  - [x] [実装](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/68/files#diff-7bcddd25f7932d01ac7047d04f9f554bffbc2d5d8f2669541cd4d477ace34215)
  - [x] [テスト](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/68/files#diff-4ee2bd9360104f82e19d93bd37cadae43e90fc7379b8ceae3fad3c038c6a3b92)
  - [x] [モック](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/68/files#diff-d7a0a48af3e670a4df60d432a12278330e256c0bdd96f65d1fc5fba0ace07bb7)

- [x] [既存のテスト](https://github.com/gn-t-k/PrAhaChallengeTasks/pull/68/files#diff-2a5e08fba19ffbdbea71f850a67fb857b5f7008d711eb257d2c9bfb3e223c25c)のリファクタ

## 見てほしいところ

仕様的に漏れがないかご確認お願いします（ペアなどの合併は実装してないです）（参加者の数が足りなくなるような場合、エラーになります）