### PR TITLE
【進捗ステータスの更新】プラハチャレンジをDDDで実装してみる

### DIFF
--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/progress/progress-repository-interface.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/progress/progress-repository-interface.ts
@@ -1,6 +1,14 @@
+import { Identifier } from "domain/__shared__/identifier";
 import { Progress } from "domain/progress/entity/progress";
+
+export interface IGetOne {
+  memberID: Identifier;
+  exerciseID: Identifier;
+}
 
 export interface IProgressRepository {
   register(progressList: Progress[]): Promise<void>;
+  getOne(props: IGetOne): Promise<Progress>;
   getAll(): Promise<Progress[]>;
+  update(progress: Progress): Promise<void>;
 }

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/change-progress-status-to-next.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/change-progress-status-to-next.ts
@@ -1,7 +1,7 @@
 import { Identifier } from "domain/__shared__/identifier";
 import { IProgressRepository } from "domain/progress/progress-repository-interface";
 
-export abstract class ChangeProgressStatus {
+export class ChangeProgressStatusNext {
   private readonly progressRepository: IProgressRepository;
 
   public constructor(progressRepository: IProgressRepository) {

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/change-progress-status-to-next.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/change-progress-status-to-next.ts
@@ -1,0 +1,22 @@
+import { Identifier } from "domain/__shared__/identifier";
+import { IProgressRepository } from "domain/progress/progress-repository-interface";
+
+export abstract class ChangeProgressStatus {
+  private readonly progressRepository: IProgressRepository;
+
+  public constructor(progressRepository: IProgressRepository) {
+    this.progressRepository = progressRepository;
+  }
+
+  public execute = async (
+    memberID: string,
+    exerciseID: string,
+  ): Promise<void> => {
+    const progress = await this.progressRepository.getOne({
+      memberID: new Identifier(memberID),
+      exerciseID: new Identifier(exerciseID),
+    });
+
+    await this.progressRepository.update(progress.changeStatusNext());
+  };
+}

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/change-progress-status-to-previous.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/change-progress-status-to-previous.ts
@@ -1,7 +1,7 @@
 import { Identifier } from "domain/__shared__/identifier";
 import { IProgressRepository } from "domain/progress/progress-repository-interface";
 
-export abstract class ChangeProgressStatus {
+export class ChangeProgressStatusPrevious {
   private readonly progressRepository: IProgressRepository;
 
   public constructor(progressRepository: IProgressRepository) {

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/change-progress-status-to-previous.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/change-progress-status-to-previous.ts
@@ -1,0 +1,22 @@
+import { Identifier } from "domain/__shared__/identifier";
+import { IProgressRepository } from "domain/progress/progress-repository-interface";
+
+export abstract class ChangeProgressStatus {
+  private readonly progressRepository: IProgressRepository;
+
+  public constructor(progressRepository: IProgressRepository) {
+    this.progressRepository = progressRepository;
+  }
+
+  public execute = async (
+    memberID: string,
+    exerciseID: string,
+  ): Promise<void> => {
+    const progress = await this.progressRepository.getOne({
+      memberID: new Identifier(memberID),
+      exerciseID: new Identifier(exerciseID),
+    });
+
+    await this.progressRepository.update(progress.changeStatusPrevious());
+  };
+}


### PR DESCRIPTION
## 対応内容

- 進捗ステータスを前にすすめるユースケース
- 進捗ステータスを後ろに戻すユースケース
- 課題進捗リポジトリにメソッド追加（findUnique的なやつとupdate）

## 見てほしいところ

仕様に漏れがないかチェックお願いします。テスト書いてないですが、作業にしかならない気がしているため勘弁してください、、