### PR TITLE
【課題の削除】プラハチャレンジをDDDで実装してみる

### DIFF
--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/exercise/exercise-repository-interface.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/exercise/exercise-repository-interface.ts
@@ -1,6 +1,9 @@
+import { Identifier } from "domain/__shared__/identifier";
 import { Exercise } from "domain/exercise/entity/exercise";
 
 export interface IExerciseRepository {
+  getByID(id: Identifier): Promise<Exercise | null>;
   getAll(): Promise<Exercise[]>;
   register(exercise: Exercise): Promise<void>;
+  deleteByID(id: Identifier): Promise<void>;
 }

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/exercise/service/is-exercise-exists-service.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/exercise/service/is-exercise-exists-service.ts
@@ -1,0 +1,13 @@
+import { Identifier } from "domain/__shared__/identifier";
+import { IExerciseRepository } from "domain/exercise/exercise-repository-interface";
+
+export class IsExerciseExistsService {
+  private readonly exerciseRepository: IExerciseRepository;
+
+  public constructor(exerciseRepository: IExerciseRepository) {
+    this.exerciseRepository = exerciseRepository;
+  }
+
+  public execute = async (id: Identifier): Promise<boolean> =>
+    (await this.exerciseRepository.getByID(id)) !== null;
+}

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/progress/progress-repository-interface.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/domain/progress/progress-repository-interface.ts
@@ -11,4 +11,5 @@ export interface IProgressRepository {
   getOne(props: IGetOne): Promise<Progress>;
   getAll(): Promise<Progress[]>;
   update(progress: Progress): Promise<void>;
+  deleteByExerciseID(exerciseID: Identifier): Promise<void>;
 }

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/infrastructure/db/repository/progress-repository.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/infrastructure/db/repository/progress-repository.ts
@@ -79,4 +79,12 @@ export class ProgressRepository implements IProgressRepository {
       },
     });
   };
+
+  public deleteByExerciseID = async (exerciseID: Identifier): Promise<void> => {
+    await this.prisma.exerciseOnMember.deleteMany({
+      where: {
+        exerciseId: exerciseID.value,
+      },
+    });
+  };
 }

--- a/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/delete-exercise.ts
+++ b/04_設計/04_プラハチャレンジをDDDで実装してみる/02_APIサーバ/src/usecase/delete-exercise.ts
@@ -1,0 +1,32 @@
+import { Identifier } from "domain/__shared__/identifier";
+import { IExerciseRepository } from "domain/exercise/exercise-repository-interface";
+import { IsExerciseExistsService } from "domain/exercise/service/is-exercise-exists-service";
+import { IProgressRepository } from "domain/progress/progress-repository-interface";
+
+export class DeleteExercise {
+  private readonly exerciseRepository: IExerciseRepository;
+  private readonly progressRepository: IProgressRepository;
+
+  public constructor(
+    exerciseRepository: IExerciseRepository,
+    progressRepository: IProgressRepository,
+  ) {
+    this.exerciseRepository = exerciseRepository;
+    this.progressRepository = progressRepository;
+  }
+
+  public execute = async (id: string): Promise<void> => {
+    const exerciseID = new Identifier(id);
+
+    const isExerciseExists = await new IsExerciseExistsService(
+      this.exerciseRepository,
+    ).execute(exerciseID);
+
+    if (!isExerciseExists) {
+      throw new Error("Exercise is not exists");
+    }
+
+    await this.progressRepository.deleteByExerciseID(exerciseID);
+    await this.exerciseRepository.deleteByID(exerciseID);
+  };
+}


### PR DESCRIPTION
## 対応内容

- 課題リポジトリにメソッド追加
- 課題が存在するかどうかIDで検索するドメインサービス
- 課題進捗リポジトリにメソッド追加
- 課題を削除するユースケース実装

## 見てほしいところ

またしても懲りずにテスト書いてないので、凡ミスとかあるかもです、、ごめんなさい